### PR TITLE
Cosmetic: cleanup imports

### DIFF
--- a/Foreign/Ruby/Helpers.hs
+++ b/Foreign/Ruby/Helpers.hs
@@ -1,18 +1,17 @@
 module Foreign.Ruby.Helpers where
 
-import Foreign.Ruby.Bindings
-
-import Data.Maybe (fromMaybe)
-import Foreign
-import Data.Aeson
 import Control.Monad
+import Data.Aeson(Value(..))
+import Data.Attoparsec.Number
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.HashMap.Strict as HM
+import Data.IORef
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import qualified Data.ByteString.Char8 as BS
-import Data.Attoparsec.Number
 import qualified Data.Vector as V
-import Data.IORef
-import qualified Data.HashMap.Strict as HM
+import Foreign
+import Foreign.Ruby.Bindings
 
 -- | The class of things that can be converted from Ruby values. Note that
 -- there are a ton of stuff that are Ruby values, hence the `Maybe` type,


### PR DESCRIPTION
I have been cleaning the import a bit (mainly because I am experiencing strange build errors with `language-puppet` even in a cabal sandbox after the Arch OS upgrade of this package).

Anyhow I hope this tiny pull request is actually useful.

As a note,`Attoparsec` is using the `scientific` package to parse numbers since 0.11.Would you be interested in upgrading `attoparsec` ? It probably breaks compatibility with previous `attoparsec` versions.
