### PR TITLE
use RbConfig to find lib/includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /dist
+cabal.sandbox.config
+.cabal-sandbox/


### PR DESCRIPTION
This pull request improves upon the existing ruby lib/includes detection by using the active `ruby` installation to query the `RbConfig::CONFIG` mapping.

I've tested this on OSX 10.9.1 using my custom build of YARV 1.9.2 (using `chruby` to manage the "active" ruby install). If I got everything right, it should work for any other OS :).
