### PR TITLE
Set upperbound for scientific

### DIFF
--- a/hruby.cabal
+++ b/hruby.cabal
@@ -31,7 +31,7 @@ library
                         , vector               >= 0.10 && < 0.11
                         , unordered-containers >= 0.2 && < 0.3
                         , stm                  >= 2.4 && < 2.5
-                        , scientific           == 0.2.*
+                        , scientific           >= 0.2 && < 0.4
   c-sources:            cbits/shim.c
   install-includes:     cbits/shim.h
   include-dirs:         cbits


### PR DESCRIPTION
I have been using `scientific-0.3.2` for a while without issues
