### PR TITLE
Update hruby.cabal

### DIFF
--- a/hruby.cabal
+++ b/hruby.cabal
@@ -29,7 +29,7 @@ library
                         , aeson                >= 0.7 && < 0.9
                         , bytestring           >= 0.10.0.2
                         , text                 >= 0.11
-                        , attoparsec           >= 0.11 && < 0.13
+                        , attoparsec           >= 0.11 && < 0.14
                         , vector               >= 0.10 && < 0.11
                         , unordered-containers >= 0.2 && < 0.3
                         , stm                  >= 2.4 && < 2.5


### PR DESCRIPTION
Allow attoparsec 0.13 (it is a mandatory deps for aeson =0.8.1)