### PR TITLE
Increase base upper bound to 5

### DIFF
--- a/hruby.cabal
+++ b/hruby.cabal
@@ -25,7 +25,7 @@ library
   ghc-options:          -Wall
   -- ghc-prof-options:     -caf-all -auto-all
   extensions:           BangPatterns, OverloadedStrings
-  build-depends:        base >= 4.6 && < 4.9
+  build-depends:        base >= 4.6 && < 5
                         , aeson                >= 0.7
                         , bytestring           >= 0.10.0.2
                         , text                 >= 0.11


### PR DESCRIPTION
It compiles with `ghc-8` according to http://hydra.cryp.to/build/1781445/log