### PR TITLE
Add ruby2.0 to the list for ubuntu 14.04

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -44,7 +44,7 @@ getRubyInfo = do
         Nothing -> return Nothing
         Just (1,9,_) -> error $ unlines [ "Ruby 1.9 cannot be integrated with the GHC runtime. Tough luck :("
                                         , "On Ubuntu 14.04, you can try this:"
-                                        , "  apt-get install libruby2.0 ruby2.0-dev"
+                                        , "  apt-get install ruby2.0 libruby2.0 ruby2.0-dev"
                                         , "  cabal install hruby -p --configure-option=\"--rubyversion=20 --rubylib=ruby-2.0 --rubyinc=/usr/include/ruby-2.0.0 --rubyinc=/usr/include/x86_64-linux-gnu/ruby-2.0.0\""
                                         ]
         Just v@(1,8,_) -> return $ Just $ RubyInfo v


### PR DESCRIPTION
You can install dev and lib without executable, and that one is required for `evalRuby` in `Setup.hs` to work.