### PR TITLE
Lower cabal-version

### DIFF
--- a/hruby.cabal
+++ b/hruby.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.2
+cabal-version:       2.0
 name:                hruby
 version:             0.3.5.2
 synopsis:            Embed a Ruby intepreter in your Haskell program !


### PR DESCRIPTION
`language-puppet` won't compile with such a higer spec version because servant won't support it.
It looks like it is best to lower the version at least to `2.0`.