### PR TITLE
Add safeFunCall, the generalization of safeMethodCall 

### DIFF
--- a/Foreign/Ruby.hs
+++ b/Foreign/Ruby.hs
@@ -14,6 +14,7 @@ module Foreign.Ruby
   , loadFile
   , Foreign.Ruby.Safe.embedHaskellValue
   , Foreign.Ruby.Safe.safeMethodCall
+  , Foreign.Ruby.Safe.safeFunCall
   , makeSafe
   , RubyError(..)
   -- * Converting to and from Ruby values

--- a/Foreign/Ruby/Bindings.hsc
+++ b/Foreign/Ruby/Bindings.hsc
@@ -111,6 +111,7 @@ foreign import ccall   safe "rb_define_module_function" c_rb_define_module_funct
 foreign import ccall   safe "rb_define_global_function" c_rb_define_global_function :: CString -> FunPtr a -> Int -> IO ()
 foreign import ccall unsafe "rb_const_get"              rb_const_get                :: RValue -> RID -> IO RValue
 foreign import ccall   safe "&safeCall"                 safeCallback                :: FunPtr (RValue -> IO RValue)
+foreign import ccall   safe "&getRubyCObject"           getRubyCObjectCallback      :: FunPtr (RValue -> IO RValue)
 foreign import ccall   safe "rb_protect"                c_rb_protect                :: FunPtr (RValue -> IO RValue) -> RValue -> Ptr Int -> IO RValue
 foreign import ccall unsafe "rb_string_value_cstr"      c_rb_string_value_cstr      :: Ptr RValue -> IO CString
 foreign import ccall unsafe "rb_ary_new"                rb_ary_new                  :: IO RValue

--- a/Foreign/Ruby/Bindings.hsc
+++ b/Foreign/Ruby/Bindings.hsc
@@ -14,18 +14,16 @@ type RValue = Ptr CULong
 -- | The Ruby ID type, mostly used for symbols.
 type RID = CULong
 
-data ShimDispatch = ShimDispatch String String [RValue]
+data ShimDispatch = ShimDispatch RID RID [RValue]
 instance Storable ShimDispatch where
     sizeOf _ = (#size struct s_dispatch)
     alignment = sizeOf
-    peek ptr = do a <- peekCString ((#ptr struct s_dispatch, classname) ptr)
-                  b <- peekCString ((#ptr struct s_dispatch, methodname) ptr)
+    peek ptr = do a <- peek ((#ptr struct s_dispatch, classid) ptr)
+                  b <- peek ((#ptr struct s_dispatch, methodid) ptr)
                   return (ShimDispatch a b [])
     poke ptr (ShimDispatch c m vals) = do
-        cs <- newCString c
-        cm <- newCString m
-        (#poke struct s_dispatch, classname) ptr cs
-        (#poke struct s_dispatch, methodname) ptr cm
+        (#poke struct s_dispatch, classid) ptr c
+        (#poke struct s_dispatch, methodid) ptr m
         (#poke struct s_dispatch, nbargs) ptr (length vals)
         let arrayblock = (#ptr struct s_dispatch, args) ptr
         pokeArray arrayblock vals

--- a/Foreign/Ruby/Bindings.hsc
+++ b/Foreign/Ruby/Bindings.hsc
@@ -14,15 +14,15 @@ type RValue = Ptr CULong
 -- | The Ruby ID type, mostly used for symbols.
 type RID = CULong
 
-data ShimDispatch = ShimDispatch RID RID [RValue]
+data ShimDispatch = ShimDispatch RValue RID [RValue]
 instance Storable ShimDispatch where
     sizeOf _ = (#size struct s_dispatch)
     alignment = sizeOf
-    peek ptr = do a <- peek ((#ptr struct s_dispatch, classid) ptr)
+    peek ptr = do a <- peek ((#ptr struct s_dispatch, receiver) ptr)
                   b <- peek ((#ptr struct s_dispatch, methodid) ptr)
                   return (ShimDispatch a b [])
     poke ptr (ShimDispatch c m vals) = do
-        (#poke struct s_dispatch, classid) ptr c
+        (#poke struct s_dispatch, receiver) ptr c
         (#poke struct s_dispatch, methodid) ptr m
         (#poke struct s_dispatch, nbargs) ptr (length vals)
         let arrayblock = (#ptr struct s_dispatch, args) ptr

--- a/Foreign/Ruby/Helpers.hs
+++ b/Foreign/Ruby/Helpers.hs
@@ -199,7 +199,9 @@ safeMethodCall classname methodname args =
     if length args > 16
         then return (Left ("too many arguments", rbNil))
         else do
-            dispatch <- new (ShimDispatch classname methodname args)
+            classid <- rb_intern classname
+            methodid <- rb_intern methodname
+            dispatch <- new (ShimDispatch classid methodid args)
             pstatus <- new 0
             o <- c_rb_protect safeCallback (castPtr dispatch) pstatus
             status <- peek pstatus

--- a/Foreign/Ruby/Safe.hs
+++ b/Foreign/Ruby/Safe.hs
@@ -15,6 +15,7 @@ module Foreign.Ruby.Safe
     , loadFile
     , embedHaskellValue
     , safeMethodCall
+    , safeFunCall
     , makeSafe
     , fromRuby
     , toRuby
@@ -115,7 +116,7 @@ makeSafe int a = do
 embedHaskellValue :: RubyInterpreter -> a -> IO (Either RubyError RValue)
 embedHaskellValue int v = makeSafe int $ FR.embedHaskellValue v
 
--- | A safe version of the corresponding "Foreign.Ruby" function.
+-- | A safe version of the corresponding "Foreign.Ruby.Helper" function.
 safeMethodCall :: RubyInterpreter
                -> String
                -> String
@@ -123,6 +124,19 @@ safeMethodCall :: RubyInterpreter
                -> IO (Either RubyError RValue)
 safeMethodCall int className methodName args = do
     o <- makeSafe int $ FR.safeMethodCall className methodName args
+    case o of
+        Left x -> return (Left x)
+        Right (Right v) -> return (Right v)
+        Right (Left (s,v)) -> return (Left (WithOutput s v))
+
+-- | A safe version of the corresponding "Foreign.Ruby.Helper" function.
+safeFunCall :: RubyInterpreter
+            -> RValue
+            -> String
+            -> [RValue]
+            -> IO (Either RubyError RValue)
+safeFunCall int receiver methodName args = do
+    o <- makeSafe int $ FR.safeFunCall receiver methodName args
     case o of
         Left x -> return (Left x)
         Right (Right v) -> return (Right v)

--- a/cbits/shim.c
+++ b/cbits/shim.c
@@ -29,10 +29,8 @@ ID sym2id(VALUE v) {
 VALUE safeCall(VALUE args)
 {
 	struct s_dispatch * d = (struct s_dispatch *) args;
-	VALUE myclass = rb_const_get(rb_cObject, rb_intern(d->classname));
-	VALUE o = rb_funcall2(myclass, rb_intern(d->methodname), d->nbargs, d->args);
-	free(d->methodname);
-	free(d->classname);
+	VALUE myclass = rb_const_get(rb_cObject, d->classid);
+	VALUE o = rb_funcall2(myclass, d->methodid, d->nbargs, d->args);
 	return o;
 }
 

--- a/cbits/shim.c
+++ b/cbits/shim.c
@@ -32,6 +32,11 @@ VALUE safeCall(VALUE args)
 	return rb_funcall2(d->receiver, d->methodid, d->nbargs, d->args);
 }
 
+VALUE getRubyCObject(VALUE name)
+{
+	return rb_const_get(rb_cObject, rb_intern((const char*) name));
+}
+
 long arrayLength(VALUE r)
 {
 	return RARRAY_LEN(r);
@@ -60,4 +65,3 @@ long num2long(VALUE v) {
 double num2dbl(VALUE v) {
 	NUM2DBL(v);
 }
-

--- a/cbits/shim.c
+++ b/cbits/shim.c
@@ -29,9 +29,7 @@ ID sym2id(VALUE v) {
 VALUE safeCall(VALUE args)
 {
 	struct s_dispatch * d = (struct s_dispatch *) args;
-	VALUE myclass = rb_const_get(rb_cObject, d->classid);
-	VALUE o = rb_funcall2(myclass, d->methodid, d->nbargs, d->args);
-	return o;
+	return rb_funcall2(d->receiver, d->methodid, d->nbargs, d->args);
 }
 
 long arrayLength(VALUE r)

--- a/cbits/shim.h
+++ b/cbits/shim.h
@@ -6,7 +6,7 @@
 void ruby_initialization(void);
 
 struct s_dispatch {
-	ID classid;
+	VALUE receiver;
 	ID methodid;
 	int nbargs;
 	VALUE args[16];

--- a/cbits/shim.h
+++ b/cbits/shim.h
@@ -6,8 +6,8 @@
 void ruby_initialization(void);
 
 struct s_dispatch {
-	char * classname;
-	char * methodname;
+	ID classid;
+	ID methodid;
 	int nbargs;
 	VALUE args[16];
 };

--- a/test/roundtrip.hs
+++ b/test/roundtrip.hs
@@ -3,6 +3,7 @@ module Main where
 import Foreign.Ruby
 import Data.Aeson
 import Control.Monad
+import System.Exit (exitFailure)
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import qualified Data.Text as T
@@ -54,4 +55,5 @@ roundTrip i = monadicIO $ do
 main :: IO ()
 main = withRubyInterpreter $ \i -> do
     loadFile i "./test/test.rb" >>= either (error . show) return
-    quickCheckWith (stdArgs { maxSuccess = 1000 } ) (roundTrip i)
+    result <- quickCheckWithResult (stdArgs { maxSuccess = 1000 } ) (roundTrip i)
+    unless (isSuccess result) exitFailure


### PR DESCRIPTION
This PR adds a function `safeFunCall` that can call any Ruby instance method in addition to singleton method while capturing a Ruby exception.

This is a generalization of `safeMethodCall` which can only call a class's (and, actually, a module's) singleton methods.

The `cbits` functions and structs are modified so that they pass `VALUE` and `ID` instead of C strings in order to pass around Ruby receivers.

The behavior of existing Haskell programs should remain the same after this change.